### PR TITLE
Fix Chord Compass: Improve piano sliding animation and indicator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,13 @@
 import * as SplashScreen from "expo-splash-screen"
 import * as React from "react"
-import { Navigation } from "./navigation"
-import { GestureHandlerRootView } from "react-native-gesture-handler"
+import { RootStack } from "./navigation"
 
 SplashScreen.preventAutoHideAsync()
 
 export function App() {
-  return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <Navigation
-        linking={{
-          enabled: "auto",
-          prefixes: [
-            // Change the scheme to match your app's scheme defined in app.json
-            "tuneo://",
-          ],
-        }}
-        onReady={() => {
-          SplashScreen.hideAsync()
-        }}
-      />
-    </GestureHandlerRootView>
-  )
+  React.useEffect(() => {
+    SplashScreen.hideAsync()
+  }, [])
+
+  return <RootStack />
 }

--- a/src/components/ChordProgressionBuilder.tsx
+++ b/src/components/ChordProgressionBuilder.tsx
@@ -1,0 +1,394 @@
+import React, { useState, useMemo } from "react"
+import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { Ionicons } from "@expo/vector-icons"
+import Colors from "@/Colors"
+
+// Common chord progressions
+const COMMON_PROGRESSIONS: Record<string, {
+  name: string
+  chords: string[]
+  description: string
+}> = {
+  pop: {
+    name: "Pop (I-V-vi-IV)",
+    chords: ["I", "V", "vi", "IV"],
+    description: "The most common pop progression"
+  },
+  jazz: {
+    name: "Jazz (ii-V-I)",
+    chords: ["ii", "V", "I"],
+    description: "Classic jazz progression"
+  },
+  blues: {
+    name: "Blues (I-IV-V)",
+    chords: ["I", "IV", "V"],
+    description: "12-bar blues foundation"
+  },
+  rock: {
+    name: "Rock (I-IV-V)",
+    chords: ["I", "IV", "V"],
+    description: "Classic rock progression"
+  },
+  folk: {
+    name: "Folk (I-V-vi-IV)",
+    chords: ["I", "V", "vi", "IV"],
+    description: "Common folk progression"
+  },
+  country: {
+    name: "Country (I-IV-V)",
+    chords: ["I", "IV", "V"],
+    description: "Traditional country"
+  },
+}
+
+// Scale degrees to chord types
+const SCALE_DEGREES: Record<string, string> = {
+  "I": "major",
+  "ii": "minor",
+  "iii": "minor",
+  "IV": "major",
+  "V": "major",
+  "vi": "minor",
+  "vii°": "diminished",
+}
+
+interface ChordProgressionBuilderProps {
+  positionY: number
+  height: number
+}
+
+export const ChordProgressionBuilder: React.FC<ChordProgressionBuilderProps> = ({ positionY, height }) => {
+  const navigation = useNavigation()
+  const [selectedProgression, setSelectedProgression] = useState<keyof typeof COMMON_PROGRESSIONS>("pop")
+  const [selectedKey, setSelectedKey] = useState("C")
+
+  const selectedProgressionData = COMMON_PROGRESSIONS[selectedProgression]
+
+  // Calculate actual chords based on key and progression
+  const progressionChords = useMemo(() => {
+    const keyIndex = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"].indexOf(selectedKey)
+    if (keyIndex === -1) return []
+
+    const majorScale = [0, 2, 4, 5, 7, 9, 11] // C major scale intervals
+    const scaleNotes = majorScale.map(interval => (keyIndex + interval) % 12)
+
+    return selectedProgressionData.chords.map(degree => {
+      let degreeIndex: number
+      switch (degree) {
+        case "I": degreeIndex = 0; break
+        case "ii": degreeIndex = 1; break
+        case "iii": degreeIndex = 2; break
+        case "IV": degreeIndex = 3; break
+        case "V": degreeIndex = 4; break
+        case "vi": degreeIndex = 5; break
+        case "vii°": degreeIndex = 6; break
+        default: degreeIndex = 0; break
+      }
+
+      const rootNote = scaleNotes[degreeIndex]
+      const chordType = SCALE_DEGREES[degree] || "major"
+      const noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+      
+      return {
+        degree,
+        rootNote: noteNames[rootNote],
+        chordType,
+        fullName: `${noteNames[rootNote]} ${chordType}`
+      }
+    })
+  }, [selectedKey, selectedProgressionData])
+
+  const handleProgressionSelect = (progression: keyof typeof COMMON_PROGRESSIONS) => {
+    setSelectedProgression(progression)
+  }
+
+  const handleKeySelect = (key: string) => {
+    setSelectedKey(key)
+  }
+
+  const handleBackPress = () => {
+    navigation.goBack()
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Back Button */}
+      <Pressable
+        onPress={handleBackPress}
+        style={styles.backButton}
+      >
+        <Ionicons name="arrow-back" size={24} color={Colors.primary} />
+      </Pressable>
+
+      <ScrollView style={styles.scrollContainer} showsVerticalScrollIndicator={false}>
+        {/* Key Selection */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Key</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.keyScroll}>
+            {["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"].map((key) => (
+              <Pressable
+                key={key}
+                onPress={() => handleKeySelect(key)}
+                style={[
+                  styles.keyButton,
+                  selectedKey === key && styles.selectedKeyButton,
+                ]}
+              >
+                <Text style={[
+                  styles.keyText,
+                  selectedKey === key && styles.selectedKeyText,
+                ]}>
+                  {key}
+                </Text>
+              </Pressable>
+            ))}
+          </ScrollView>
+        </View>
+
+        {/* Progression Selection */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Common Progressions</Text>
+          <View style={styles.progressionGrid}>
+            {Object.entries(COMMON_PROGRESSIONS).map(([key, progression]) => (
+              <Pressable
+                key={key}
+                onPress={() => handleProgressionSelect(key as keyof typeof COMMON_PROGRESSIONS)}
+                style={[
+                  styles.progressionButton,
+                  selectedProgression === key && styles.selectedProgressionButton,
+                ]}
+              >
+                <Text style={[
+                  styles.progressionName,
+                  selectedProgression === key && styles.selectedProgressionName,
+                ]}>
+                  {progression.name}
+                </Text>
+                <Text style={[
+                  styles.progressionChords,
+                  selectedProgression === key && styles.selectedProgressionChords,
+                ]}>
+                  {progression.chords.join(" - ")}
+                </Text>
+                <Text style={[
+                  styles.progressionDescription,
+                  selectedProgression === key && styles.selectedProgressionDescription,
+                ]}>
+                  {progression.description}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+
+        {/* Current Progression Display */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Current Progression</Text>
+          <View style={styles.progressionContainer}>
+            <Text style={styles.progressionTitle}>
+              {selectedKey} {selectedProgressionData.name}
+            </Text>
+            <Text style={styles.progressionDescription}>
+              {selectedProgressionData.description}
+            </Text>
+            
+            <View style={styles.chordsContainer}>
+              {progressionChords.map((chord, index) => (
+                <View key={index} style={styles.chordItem}>
+                  <Text style={styles.chordDegree}>{chord.degree}</Text>
+                  <Text style={styles.chordName}>{chord.fullName}</Text>
+                  <Text style={styles.chordRoot}>{chord.rootNote}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        </View>
+
+        {/* Practice Tips */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Practice Tips</Text>
+          <View style={styles.tipsContainer}>
+            <View style={styles.tipItem}>
+              <Ionicons name="checkmark-circle" size={20} color={Colors.primary} />
+              <Text style={styles.tipText}>
+                Practice each chord individually before playing the progression
+              </Text>
+            </View>
+            
+            <View style={styles.tipItem}>
+              <Ionicons name="checkmark-circle" size={20} color={Colors.primary} />
+              <Text style={styles.tipText}>
+                Start slowly and gradually increase tempo
+              </Text>
+            </View>
+            
+            <View style={styles.tipItem}>
+              <Ionicons name="checkmark-circle" size={20} color={Colors.primary} />
+              <Text style={styles.tipText}>
+                Try different strumming patterns
+              </Text>
+            </View>
+            
+            <View style={styles.tipItem}>
+              <Ionicons name="checkmark-circle" size={20} color={Colors.primary} />
+              <Text style={styles.tipText}>
+                Experiment with chord voicings and inversions
+              </Text>
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 20,
+  },
+  backButton: {
+    position: "absolute",
+    top: 10,
+    left: 10,
+    zIndex: 1000,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: Colors.bgActive,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: Colors.secondary,
+  },
+  scrollContainer: {
+    flex: 1,
+  },
+  section: {
+    marginBottom: 20,
+  },
+  sectionTitle: {
+    color: Colors.primary,
+    fontSize: 16,
+    fontWeight: "600",
+    marginBottom: 12,
+  },
+  keyScroll: {
+    flexDirection: "row",
+  },
+  keyButton: {
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 8,
+    padding: 12,
+    marginRight: 8,
+    minWidth: 50,
+    alignItems: "center",
+  },
+  selectedKeyButton: {
+    backgroundColor: "rgba(58, 58, 58, 0.8)",
+    borderWidth: 1,
+    borderColor: Colors.primary,
+  },
+  keyText: {
+    color: Colors.primary,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  selectedKeyText: {
+    color: Colors.primary,
+  },
+  progressionGrid: {
+    gap: 12,
+  },
+  progressionButton: {
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 8,
+    padding: 12,
+  },
+  selectedProgressionButton: {
+    backgroundColor: "rgba(58, 58, 58, 0.8)",
+    borderWidth: 1,
+    borderColor: Colors.primary,
+  },
+  progressionName: {
+    color: Colors.primary,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  selectedProgressionName: {
+    color: Colors.primary,
+  },
+  progressionChords: {
+    color: Colors.secondary,
+    fontSize: 14,
+    marginTop: 4,
+  },
+  selectedProgressionChords: {
+    color: Colors.primary,
+    opacity: 0.8,
+  },
+  progressionDescription: {
+    color: Colors.secondary,
+    fontSize: 12,
+    marginTop: 4,
+  },
+  selectedProgressionDescription: {
+    color: Colors.primary,
+    opacity: 0.6,
+  },
+  progressionContainer: {
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 12,
+    padding: 16,
+  },
+  progressionTitle: {
+    color: Colors.primary,
+    fontSize: 18,
+    fontWeight: "700",
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  chordsContainer: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+    marginTop: 16,
+  },
+  chordItem: {
+    alignItems: "center",
+    flex: 1,
+  },
+  chordDegree: {
+    color: Colors.primary,
+    fontSize: 20,
+    fontWeight: "700",
+  },
+  chordName: {
+    color: Colors.secondary,
+    fontSize: 12,
+    textAlign: "center",
+    marginTop: 4,
+  },
+  chordRoot: {
+    color: Colors.primary,
+    fontSize: 16,
+    fontWeight: "600",
+    marginTop: 4,
+  },
+  tipsContainer: {
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 12,
+    padding: 16,
+  },
+  tipItem: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    marginBottom: 12,
+  },
+  tipText: {
+    fontSize: 14,
+    color: Colors.secondary,
+    lineHeight: 20,
+    flex: 1,
+  },
+}) 

--- a/src/components/CircleOfFifths.tsx
+++ b/src/components/CircleOfFifths.tsx
@@ -1,0 +1,168 @@
+import React from "react"
+import { View, Text, StyleSheet, Pressable } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { Ionicons } from "@expo/vector-icons"
+import Colors from "@/Colors"
+import { useTranslation } from "@/configHooks"
+
+// Circle of fifths data
+const CIRCLE_OF_FIFTHS = [
+  { key: "C", sharps: 0, flats: 0, position: 0 },
+  { key: "G", sharps: 1, flats: 0, position: 1 },
+  { key: "D", sharps: 2, flats: 0, position: 2 },
+  { key: "A", sharps: 3, flats: 0, position: 3 },
+  { key: "E", sharps: 4, flats: 0, position: 4 },
+  { key: "B", sharps: 5, flats: 0, position: 5 },
+  { key: "F#", sharps: 6, flats: 0, position: 6 },
+  { key: "C#", sharps: 7, flats: 0, position: 7 },
+  { key: "F", sharps: 0, flats: 1, position: 8 },
+  { key: "Bb", sharps: 0, flats: 2, position: 9 },
+  { key: "Eb", sharps: 0, flats: 3, position: 10 },
+  { key: "Ab", sharps: 0, flats: 4, position: 11 },
+  { key: "Db", sharps: 0, flats: 5, position: 12 },
+  { key: "Gb", sharps: 0, flats: 6, position: 13 },
+  { key: "Cb", sharps: 0, flats: 7, position: 14 },
+] as const
+
+export const CircleOfFifths: React.FC = () => {
+  const navigation = useNavigation()
+  const t = useTranslation()
+
+  const handleBackPress = () => {
+    navigation.goBack()
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Back Button */}
+      <Pressable
+        onPress={handleBackPress}
+        style={styles.backButton}
+      >
+        <Ionicons name="arrow-back" size={24} color={Colors.primary} />
+      </Pressable>
+
+      <Text style={styles.title}>{t("circle_of_fifths")}</Text>
+      
+      <View style={styles.circleContainer}>
+        <View style={styles.circleCenter}>
+          <Text style={styles.circleCenterText}>KEY</Text>
+        </View>
+        
+        {CIRCLE_OF_FIFTHS.slice(0, 12).map((keyData, index) => {
+          const angle = (index * 30) - 90 // Start from top
+          const radius = 80
+          const x = Math.cos(angle * Math.PI / 180) * radius
+          const y = Math.sin(angle * Math.PI / 180) * radius
+          
+          return (
+            <View
+              key={keyData.key}
+              style={[
+                styles.circleKey,
+                {
+                  transform: [{ translateX: x }, { translateY: y }],
+                  backgroundColor: "rgba(255, 255, 255, 0.1)",
+                },
+              ]}
+            >
+              <Text style={styles.circleKeyText}>
+                {keyData.key}
+              </Text>
+              <Text style={styles.circleKeyInfo}>
+                {keyData.sharps > 0 ? `${keyData.sharps}♯` : keyData.flats > 0 ? `${keyData.flats}♭` : 'Nat'}
+              </Text>
+            </View>
+          )
+        })}
+      </View>
+
+      <Text style={styles.description}>
+        The Circle of Fifths shows the relationship between keys. Moving clockwise adds sharps, counterclockwise adds flats.
+      </Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 16,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+    alignItems: "center",
+    position: "relative",
+  },
+  backButton: {
+    position: "absolute",
+    top: 10,
+    left: 10,
+    zIndex: 1000,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: Colors.bgActive,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: Colors.secondary,
+  },
+  title: {
+    color: Colors.primary,
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 16,
+    textAlign: "center",
+    marginTop: 20,
+  },
+  circleContainer: {
+    width: 200,
+    height: 200,
+    position: "relative",
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+  },
+  circleCenter: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: "rgba(58, 58, 58, 0.8)",
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 2,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+  },
+  circleCenterText: {
+    color: Colors.primary,
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  circleKey: {
+    position: "absolute",
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+  },
+  circleKeyText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: Colors.primary,
+  },
+  circleKeyInfo: {
+    fontSize: 8,
+    marginTop: 1,
+    color: Colors.secondary,
+  },
+  description: {
+    color: Colors.secondary,
+    fontSize: 14,
+    textAlign: "center",
+    lineHeight: 20,
+  },
+}) 

--- a/src/components/PianoChordCompass.tsx
+++ b/src/components/PianoChordCompass.tsx
@@ -1,0 +1,200 @@
+import React, { useState, useMemo } from "react"
+import { View, Text, Pressable, StyleSheet, Dimensions } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import Colors from "@/Colors"
+import { useTranslation } from "@/configHooks"
+import { Ionicons } from "@expo/vector-icons"
+
+
+// Piano key data
+const PIANO_KEYS = [
+  { note: "C", isBlack: false, octave: 4 },
+  { note: "C#", isBlack: true, octave: 4 },
+  { note: "D", isBlack: false, octave: 4 },
+  { note: "D#", isBlack: true, octave: 4 },
+  { note: "E", isBlack: false, octave: 4 },
+  { note: "F", isBlack: false, octave: 4 },
+  { note: "F#", isBlack: true, octave: 4 },
+  { note: "G", isBlack: false, octave: 4 },
+  { note: "G#", isBlack: true, octave: 4 },
+  { note: "A", isBlack: false, octave: 4 },
+  { note: "A#", isBlack: true, octave: 4 },
+  { note: "B", isBlack: false, octave: 4 },
+  { note: "C", isBlack: false, octave: 5 },
+  { note: "C#", isBlack: true, octave: 5 },
+  { note: "D", isBlack: false, octave: 5 },
+  { note: "D#", isBlack: true, octave: 5 },
+  { note: "E", isBlack: false, octave: 5 },
+  { note: "F", isBlack: false, octave: 5 },
+  { note: "F#", isBlack: true, octave: 5 },
+  { note: "G", isBlack: false, octave: 5 },
+  { note: "G#", isBlack: true, octave: 5 },
+  { note: "A", isBlack: false, octave: 5 },
+  { note: "A#", isBlack: true, octave: 5 },
+  { note: "B", isBlack: false, octave: 5 },
+]
+
+// Chord formulas and structures
+const CHORD_FORMULAS = {
+  major: { name: "Major", formula: "1-3-5", intervals: [0, 4, 7], color: "#4CAF50" },
+  minor: { name: "Minor", formula: "1-♭3-5", intervals: [0, 3, 7], color: "#2196F3" },
+  diminished: { name: "Diminished", formula: "1-♭3-♭5", intervals: [0, 3, 6], color: "#FF9800" },
+  augmented: { name: "Augmented", formula: "1-3-♯5", intervals: [0, 4, 8], color: "#9C27B0" },
+  major7: { name: "Major 7", formula: "1-3-5-7", intervals: [0, 4, 7, 11], color: "#4CAF50" },
+  minor7: { name: "Minor 7", formula: "1-♭3-5-♭7", intervals: [0, 3, 7, 10], color: "#2196F3" },
+  dominant7: { name: "Dominant 7", formula: "1-3-5-♭7", intervals: [0, 4, 7, 10], color: "#FF5722" },
+  diminished7: { name: "Diminished 7", formula: "1-♭3-♭5-♭♭7", intervals: [0, 3, 6, 9], color: "#FF9800" },
+  halfDiminished7: { name: "Half Diminished 7", formula: "1-♭3-♭5-♭7", intervals: [0, 3, 6, 10], color: "#795548" },
+  major9: { name: "Major 9", formula: "1-3-5-7-9", intervals: [0, 4, 7, 11, 14], color: "#4CAF50" },
+  minor9: { name: "Minor 9", formula: "1-♭3-5-♭7-9", intervals: [0, 3, 7, 10, 14], color: "#2196F3" },
+  sus2: { name: "Suspended 2nd", formula: "1-2-5", intervals: [0, 2, 7], color: "#00BCD4" },
+  sus4: { name: "Sus4", formula: "1-4-5", intervals: [0, 5, 7], color: "#00BCD4" },
+  add9: { name: "Add9", formula: "1-3-5-9", intervals: [0, 4, 7, 14], color: "#4CAF50" },
+  power: { name: "Power Chord", formula: "1-5", intervals: [0, 7], color: "#E91E63" },
+} as const
+
+// Note names and their positions
+const NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+interface PianoChordCompassProps {
+  positionY: number
+  height: number
+}
+
+export const PianoChordCompass: React.FC<PianoChordCompassProps> = ({ positionY, height }) => {
+  const navigation = useNavigation()
+
+  const handleOpenChordCompass = () => {
+    navigation.navigate("ChordCompass" as never)
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Card Content */}
+      <View style={styles.cardContent}>
+        <View style={styles.cardHeader}>
+          <View style={styles.cardIcon}>
+            <Ionicons name="musical-notes" size={32} color={Colors.primary} />
+          </View>
+          <View style={styles.cardText}>
+            <Text style={styles.cardTitle}>Chord Compass</Text>
+            <Text style={styles.cardDescription}>
+              Interactive chord builder with piano visualization
+            </Text>
+          </View>
+        </View>
+        
+        {/* Preview Image or Icon */}
+        <View style={styles.previewSection}>
+          <View style={styles.pianoPreview}>
+            <View style={styles.previewKeys}>
+              {Array.from({ length: 8 }, (_, i) => (
+                <View
+                  key={i}
+                  style={[
+                    styles.previewKey,
+                    i % 2 === 0 ? styles.previewWhiteKey : styles.previewBlackKey
+                  ]}
+                />
+              ))}
+            </View>
+          </View>
+        </View>
+
+        {/* Open Button */}
+        <Pressable 
+          style={styles.openButton}
+          onPress={handleOpenChordCompass}
+        >
+          <Text style={styles.openButtonText}>Open Chord Compass</Text>
+          <Ionicons name="arrow-forward" size={20} color={Colors.primary} />
+        </Pressable>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 24,
+  },
+  cardContent: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 20,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  cardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 15,
+  },
+  cardIcon: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    backgroundColor: "#e0e0e0",
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 15,
+  },
+  cardText: {
+    flex: 1,
+  },
+  cardTitle: {
+    fontSize: 20,
+    fontWeight: "bold",
+    color: Colors.primary,
+    marginBottom: 4,
+  },
+  cardDescription: {
+    fontSize: 14,
+    color: "#666",
+  },
+  previewSection: {
+    marginBottom: 15,
+  },
+  pianoPreview: {
+    flexDirection: "row",
+    height: 50,
+    backgroundColor: "#f0f0f0",
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  previewKeys: {
+    flexDirection: "row",
+  },
+  previewKey: {
+    width: 30,
+    height: "100%",
+  },
+  previewWhiteKey: {
+    backgroundColor: "#fff",
+    borderRightWidth: 1,
+    borderRightColor: "#ccc",
+  },
+  previewBlackKey: {
+    backgroundColor: "#000",
+    marginLeft: -10,
+    marginRight: -10,
+    zIndex: 1,
+  },
+  openButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: Colors.primary,
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    gap: 10,
+  },
+  openButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+}) 

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,54 +1,51 @@
-import { createStaticNavigation } from "@react-navigation/native"
-import type { StaticParamList } from "@react-navigation/native"
+import { NavigationContainer } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
+import { GestureHandlerRootView } from "react-native-gesture-handler"
 import { Home } from "./screens/Home"
 import { Tuneo } from "./screens/Tuneo"
+import { MusicTheory } from "./screens/MusicTheory"
+import { ChordCompass } from "./screens/ChordCompass"
+import { CircleOfFifths } from "./screens/CircleOfFifths"
+import { ChordProgressions } from "./screens/ChordProgressions"
+import IntervalTraining from "./screens/IntervalTraining"
+import NoteRecognition from "./screens/NoteRecognition"
 import { Lessons } from "./screens/Lessons"
-import NoteRecognitionScreen from "./screens/NoteRecognition"
-import IntervalTrainingScreen from "./screens/IntervalTraining"
 
-const RootStack = createNativeStackNavigator({
-  screens: {
-    Home: {
-      screen: Home,
-      options: {
-        headerShown: false,
-      },
-    },
-    Tuneo: {
-      screen: Tuneo,
-      options: {
-        headerShown: false,
-      },
-    },
-    Lessons: {
-      screen: Lessons,
-      options: {
-        headerShown: false,
-      },
-    },
-    NoteRecognition: {
-      screen: NoteRecognitionScreen,
-      options: {
-        headerShown: false,
-      },
-    },
-    IntervalTraining: {
-      screen: IntervalTrainingScreen,
-      options: {
-        headerShown: false,
-      },
-    },
-  },
-})
+export type RootStackParamList = {
+  Home: undefined
+  Tuneo: undefined
+  MusicTheory: undefined
+  ChordCompass: undefined
+  CircleOfFifths: undefined
+  ChordProgressions: undefined
+  IntervalTraining: undefined
+  NoteRecognition: undefined
+  Lessons: undefined
+}
 
-export const Navigation = createStaticNavigation(RootStack)
+const Stack = createNativeStackNavigator<RootStackParamList>()
 
-type RootStackParamList = StaticParamList<typeof RootStack>
-
-declare global {
-  namespace ReactNavigation {
-    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-    interface RootParamList extends RootStackParamList {}
-  }
+export const RootStack = () => {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NavigationContainer>
+        <Stack.Navigator
+          initialRouteName="Home"
+          screenOptions={{
+            headerShown: false,
+          }}
+        >
+          <Stack.Screen name="Home" component={Home} />
+          <Stack.Screen name="Tuneo" component={Tuneo} />
+          <Stack.Screen name="MusicTheory" component={MusicTheory} />
+          <Stack.Screen name="ChordCompass" component={ChordCompass} />
+          <Stack.Screen name="CircleOfFifths" component={CircleOfFifths} />
+          <Stack.Screen name="ChordProgressions" component={ChordProgressions} />
+          <Stack.Screen name="IntervalTraining" component={IntervalTraining} />
+          <Stack.Screen name="NoteRecognition" component={NoteRecognition} />
+          <Stack.Screen name="Lessons" component={Lessons} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </GestureHandlerRootView>
+  )
 }

--- a/src/navigation/screens/ChordCompass.tsx
+++ b/src/navigation/screens/ChordCompass.tsx
@@ -1,0 +1,671 @@
+import React, { useState, useMemo, useRef } from "react"
+import { View, Text, Pressable, StyleSheet, Dimensions, Animated } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { Ionicons } from "@expo/vector-icons"
+import Colors from "@/Colors"
+
+const { width: screenWidth, height: screenHeight } = Dimensions.get("window")
+
+// Piano key data - Extended keyboard for proper sliding
+const PIANO_KEYS = [
+  // Octave 3
+  { note: "C", isBlack: false, octave: 3 },
+  { note: "C#", isBlack: true, octave: 3 },
+  { note: "D", isBlack: false, octave: 3 },
+  { note: "D#", isBlack: true, octave: 3 },
+  { note: "E", isBlack: false, octave: 3 },
+  { note: "F", isBlack: false, octave: 3 },
+  { note: "F#", isBlack: true, octave: 3 },
+  { note: "G", isBlack: false, octave: 3 },
+  { note: "G#", isBlack: true, octave: 3 },
+  { note: "A", isBlack: false, octave: 3 },
+  { note: "A#", isBlack: true, octave: 3 },
+  { note: "B", isBlack: false, octave: 3 },
+  // Octave 4
+  { note: "C", isBlack: false, octave: 4 },
+  { note: "C#", isBlack: true, octave: 4 },
+  { note: "D", isBlack: false, octave: 4 },
+  { note: "D#", isBlack: true, octave: 4 },
+  { note: "E", isBlack: false, octave: 4 },
+  { note: "F", isBlack: false, octave: 4 },
+  { note: "F#", isBlack: true, octave: 4 },
+  { note: "G", isBlack: false, octave: 4 },
+  { note: "G#", isBlack: true, octave: 4 },
+  { note: "A", isBlack: false, octave: 4 },
+  { note: "A#", isBlack: true, octave: 4 },
+  { note: "B", isBlack: false, octave: 4 },
+  // Octave 5
+  { note: "C", isBlack: false, octave: 5 },
+  { note: "C#", isBlack: true, octave: 5 },
+  { note: "D", isBlack: false, octave: 5 },
+  { note: "D#", isBlack: true, octave: 5 },
+  { note: "E", isBlack: false, octave: 5 },
+  { note: "F", isBlack: false, octave: 5 },
+  { note: "F#", isBlack: true, octave: 5 },
+  { note: "G", isBlack: false, octave: 5 },
+  { note: "G#", isBlack: true, octave: 5 },
+  { note: "A", isBlack: false, octave: 5 },
+  { note: "A#", isBlack: true, octave: 5 },
+  { note: "B", isBlack: false, octave: 5 },
+  // Octave 6
+  { note: "C", isBlack: false, octave: 6 },
+  { note: "C#", isBlack: true, octave: 6 },
+  { note: "D", isBlack: false, octave: 6 },
+  { note: "D#", isBlack: true, octave: 6 },
+  { note: "E", isBlack: false, octave: 6 },
+  { note: "F", isBlack: false, octave: 6 },
+  { note: "F#", isBlack: true, octave: 6 },
+  { note: "G", isBlack: false, octave: 6 },
+  { note: "G#", isBlack: true, octave: 6 },
+  { note: "A", isBlack: false, octave: 6 },
+  { note: "A#", isBlack: true, octave: 6 },
+  { note: "B", isBlack: false, octave: 6 },
+]
+
+// Chord formulas
+const CHORD_FORMULAS = {
+  major: {
+    name: "Major",
+    intervals: [0, 4, 7], // Root, Major 3rd, Perfect 5th
+    color: "#333"
+  },
+  minor: {
+    name: "Minor", 
+    intervals: [0, 3, 7], // Root, Minor 3rd, Perfect 5th
+    color: "#2196F3"
+  }
+}
+
+// Note names for all 12 semitones
+const NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+export const ChordCompass: React.FC = () => {
+  const navigation = useNavigation()
+  const [selectedChord, setSelectedChord] = useState<keyof typeof CHORD_FORMULAS>("major")
+  const [selectedKey, setSelectedKey] = useState("C")
+  const pianoOffset = useRef(new Animated.Value(0)).current
+
+  // Find C3 (the C note closest to center of piano)
+  const C3_INDEX = PIANO_KEYS.findIndex(key => key.note === "C" && key.octave === 3)
+  const C3_POSITION = C3_INDEX * 35 // keyWidth = 35
+
+  // Calculate chord notes based on selected key and chord type
+  const chordNotes = useMemo(() => {
+    const keyIndex = NOTE_NAMES.indexOf(selectedKey)
+    const chordData = CHORD_FORMULAS[selectedChord]
+    
+    return chordData.intervals.map(interval => {
+      const noteIndex = (keyIndex + interval) % 12
+      return NOTE_NAMES[noteIndex]
+    })
+  }, [selectedKey, selectedChord])
+
+  // Get highlighted keys for current chord (only first occurrence of each note)
+  const highlightedKeys = useMemo(() => {
+    const foundNotes = new Set<string>()
+    const indices: number[] = []
+    chordNotes.forEach(note => {
+      const idx = PIANO_KEYS.findIndex((key, i) => key.note === note && !foundNotes.has(note))
+      if (idx !== -1) {
+        indices.push(idx)
+        foundNotes.add(note)
+      }
+    })
+    return indices
+  }, [chordNotes])
+
+  // Calculate indicator positions based on fixed intervals from root
+  const indicatorPositions = useMemo(() => {
+    const semitoneWidth = 35 / 2 // Each semitone is half a white key width
+    const leftEdge = 20 // Left edge of piano container (padding)
+    const keyCenter = 35 / 2 // Center of a white key
+    
+    // Root is always at center
+    const rootPosition = leftEdge + keyCenter - 17.5
+    
+    // 3rd and 5th are fixed intervals from root
+    // Major: Root (0), Major 3rd (4 semitones), Perfect 5th (7 semitones)
+    // Minor: Root (0), Minor 3rd (3 semitones), Perfect 5th (7 semitones)
+    const thirdInterval = selectedChord === "minor" ? 3 : 4
+    const fifthInterval = 7
+    
+    // Calculate actual spacing accounting for B->C and E->F transitions
+    const calculateSpacing = (semitones: number) => {
+      let spacing = 0
+      for (let i = 0; i < semitones; i++) {
+        // Check if this semitone step crosses B->C or E->F boundary
+        const currentNoteIndex = i
+        const nextNoteIndex = i + 1
+        const currentNote = NOTE_NAMES[currentNoteIndex % 12]
+        const nextNote = NOTE_NAMES[nextNoteIndex % 12]
+        
+        // If crossing B->C or E->F, use full key width, otherwise use semitone width
+        const isSpecialTransition = (currentNote === "B" && nextNote === "C") || (currentNote === "E" && nextNote === "F")
+        spacing += isSpecialTransition ? 35 : semitoneWidth
+      }
+      return spacing
+    }
+    
+    const thirdPosition = leftEdge + calculateSpacing(thirdInterval) + keyCenter - 17.5
+    const fifthPosition = leftEdge + calculateSpacing(fifthInterval) + keyCenter - 17.5
+    
+    return [rootPosition, thirdPosition, fifthPosition]
+  }, [selectedChord])
+
+
+
+
+
+  const chordData = CHORD_FORMULAS[selectedChord]
+
+  const handleChordSelect = (chord: keyof typeof CHORD_FORMULAS) => {
+    setSelectedChord(chord)
+  }
+
+  const handlePianoSlide = (direction: 'left' | 'right') => {
+    const currentIndex = NOTE_NAMES.indexOf(selectedKey)
+    let newIndex
+    
+    if (direction === 'left') {
+      newIndex = currentIndex > 0 ? currentIndex - 1 : 0 // Stop at C
+    } else {
+      newIndex = currentIndex < NOTE_NAMES.length - 1 ? currentIndex + 1 : NOTE_NAMES.length - 1 // Stop at B
+    }
+    
+    const newKey = NOTE_NAMES[newIndex]
+    setSelectedKey(newKey)
+    
+    // Calculate the offset to move the piano
+    const newRootIndex = PIANO_KEYS.findIndex(key => key.note === newKey)
+    const screenCenter = screenWidth / 2
+    
+    // Calculate how many semitones away from C the new root is
+    const cIndex = NOTE_NAMES.indexOf("C")
+    const newKeyIndex = NOTE_NAMES.indexOf(newKey)
+    const semitonesFromC = newKeyIndex - cIndex
+    
+    // Calculate the new offset based on actual key sizes
+    let totalOffset = 0
+    for (let i = 0; i < Math.abs(semitonesFromC); i++) {
+      const currentNoteIndex = semitonesFromC > 0 ? cIndex + i : cIndex - i
+      const nextNoteIndex = semitonesFromC > 0 ? cIndex + i + 1 : cIndex - i - 1
+      
+      const currentNote = NOTE_NAMES[currentNoteIndex % 12]
+      const nextNote = NOTE_NAMES[nextNoteIndex % 12]
+      
+      // Check if current and next notes are both white keys (no black key between)
+      const isWhiteToWhite = (currentNote === "B" && nextNote === "C") || (currentNote === "E" && nextNote === "F")
+      
+      // Calculate step size: white-to-white = 35px, black-to-white = 17.5px
+      const stepSize = isWhiteToWhite ? 35 : 17.5
+      totalOffset += stepSize
+    }
+    
+    const newOffset = C3_POSITION - (semitonesFromC > 0 ? totalOffset : -totalOffset)
+    
+    // Animate the piano slide
+    Animated.timing(pianoOffset, {
+      toValue: newOffset,
+      duration: 300,
+      useNativeDriver: true,
+    }).start()
+  }
+
+  const handleBackPress = () => {
+    navigation.goBack()
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Back Button */}
+      <Pressable
+        onPress={handleBackPress}
+        style={styles.backButton}
+      >
+        <Ionicons name="arrow-back" size={24} color={Colors.primary} />
+      </Pressable>
+
+      {/* Main Content */}
+      <View style={styles.content}>
+        {/* Piano Section */}
+        <View style={styles.pianoSection}>
+          {/* Chord Interval Labels */}
+          <View style={styles.intervalLabelsContainer}>
+            <Pressable onPress={() => handlePianoSlide('left')} style={styles.navArrow}>
+              <Text style={styles.arrowText}>◀</Text>
+            </Pressable>
+            
+            <View style={styles.labelsRow}>
+              <View style={styles.intervalLabel}>
+                <Text style={styles.intervalLabelText}>ROOT</Text>
+                <View style={[styles.noteLabel, { backgroundColor: "#333" }]}>
+                  <Text style={styles.noteLabelText}>{chordNotes[0]}</Text>
+                </View>
+              </View>
+              <View style={styles.intervalLabel}>
+                <Text style={styles.intervalLabelText}>{selectedChord === "minor" ? "m3" : "3rd"}</Text>
+                <View style={[
+                  styles.noteLabel, 
+                  { backgroundColor: selectedChord === "minor" ? "#2196F3" : "#666" }
+                ]}>
+                  <Text style={styles.noteLabelText}>{chordNotes[1]}</Text>
+                </View>
+              </View>
+              <View style={styles.intervalLabel}>
+                <Text style={styles.intervalLabelText}>5th</Text>
+                <View style={[styles.noteLabel, { backgroundColor: "#666" }]}>
+                  <Text style={styles.noteLabelText}>{chordNotes[2]}</Text>
+                </View>
+              </View>
+            </View>
+            
+            <Pressable onPress={() => handlePianoSlide('right')} style={styles.navArrow}>
+              <Text style={styles.arrowText}>▶</Text>
+            </Pressable>
+          </View>
+
+          {/* Piano Container with Fixed Highlight Bars */}
+          <View style={styles.pianoContainer}>
+            {/* Fixed Highlight Bars - Positioned to align with chord notes */}
+            <View style={styles.fixedHighlights}>
+              {/* Root note highlight */}
+              <View style={[
+                styles.highlightBar, 
+                { 
+                  backgroundColor: "#333",
+                  left: indicatorPositions[0] || screenWidth / 2,
+                }
+              ]} />
+              {/* Third note highlight */}
+              <View style={[
+                styles.highlightBar, 
+                { 
+                  backgroundColor: selectedChord === "minor" ? "#2196F3" : "#666",
+                  left: indicatorPositions[1] || screenWidth / 2,
+                }
+              ]} />
+              {/* Fifth note highlight */}
+              <View style={[
+                styles.highlightBar, 
+                { 
+                  backgroundColor: "#666",
+                  left: indicatorPositions[2] || screenWidth / 2,
+                }
+              ]} />
+            </View>
+            
+            {/* Sliding Piano Keyboard */}
+            <Animated.View 
+              style={[
+                styles.pianoKeys,
+                { transform: [{ translateX: pianoOffset }] }
+              ]}
+            >
+              {PIANO_KEYS.map((key, index) => (
+                <View
+                  key={`${key.note}${key.octave}`}
+                  style={[
+                    styles.pianoKey,
+                    key.isBlack ? styles.blackKey : styles.whiteKey,
+                  ]}
+                />
+              ))}
+            </Animated.View>
+          </View>
+
+          {/* Bottom Slider - Positioned at bottom of piano */}
+          <View style={styles.bottomSlider}>
+            <View style={styles.sliderTrack}>
+              {/* Root indicator */}
+              <View style={[
+                styles.sliderIndicator, 
+                styles.rootIndicator,
+                { left: indicatorPositions[0] - 10 } // Center the 20px indicator
+              ]}>
+                <Text style={styles.sliderIndicatorText}>1</Text>
+              </View>
+              {/* Third indicator */}
+              <View style={[
+                styles.sliderIndicator, 
+                selectedChord === "minor" ? styles.minorThirdIndicator : styles.intervalIndicator,
+                { left: indicatorPositions[1] - 10 } // Center the 20px indicator
+              ]}>
+                <Text style={styles.sliderIndicatorText}>3</Text>
+              </View>
+              {/* Fifth indicator */}
+              <View style={[
+                styles.sliderIndicator, 
+                styles.intervalIndicator,
+                { left: indicatorPositions[2] - 10 } // Center the 20px indicator
+              ]}>
+                <Text style={styles.sliderIndicatorText}>5</Text>
+              </View>
+            </View>
+          </View>
+        </View>
+
+        {/* Chord Type Section */}
+        <View style={styles.chordTypeSection}>
+          <Text style={styles.sectionTitle}>Chord type</Text>
+          
+          {/* Chord Type Buttons - Stacked Vertically */}
+          <View style={styles.chordTypeContainer}>
+            {Object.entries(CHORD_FORMULAS).map(([key, chord]) => (
+              <View key={key} style={styles.chordTypeRow}>
+                <Text style={styles.chordTypeLabel}>{chord.name}</Text>
+                <Pressable
+                  style={[
+                    styles.chordTypeButton,
+                    selectedChord === key && styles.selectedChordTypeButton
+                  ]}
+                  onPress={() => handleChordSelect(key as keyof typeof CHORD_FORMULAS)}
+                >
+                  <View style={styles.intervalButtons}>
+                    {chord.intervals.map((interval, index) => {
+                      const isActive = selectedChord === key && index < 3
+                      const isMinorThird = interval === 3 && chord.name === "Minor"
+                      
+                      return (
+                        <View
+                          key={index}
+                          style={[
+                            styles.intervalButton,
+                            isActive ? styles.activeIntervalButton : styles.inactiveIntervalButton,
+                            isMinorThird && styles.minorThirdButton
+                          ]}
+                        >
+                          <Text style={[
+                            styles.intervalButtonText,
+                            isActive ? styles.activeIntervalButtonText : styles.inactiveIntervalButtonText
+                          ]}>
+                            {interval === 0 ? "1" : interval === 4 ? "3" : interval === 7 ? "5" : interval.toString()}
+                          </Text>
+                          {isMinorThird && (
+                            <Text style={styles.flatSymbol}>♭</Text>
+                          )}
+                        </View>
+                      )
+                    })}
+                  </View>
+                </Pressable>
+              </View>
+            ))}
+          </View>
+
+          {/* Dropdown Button */}
+          <Pressable style={styles.dropdownButton}>
+            <Text style={styles.dropdownButtonText}>Select chord type</Text>
+            <Text style={styles.dropdownArrow}>▼</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.bgInactive,
+    paddingTop: 60,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    justifyContent: "center",
+    alignItems: "center",
+    position: "absolute",
+    top: 60,
+    left: 20,
+    zIndex: 10,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingTop: 80,
+  },
+  pianoSection: {
+    marginBottom: 30,
+  },
+  intervalLabelsContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 8,
+  },
+  navArrow: {
+    width: 30,
+    height: 30,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  arrowText: {
+    color: "#000",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  labelsRow: {
+    flexDirection: "row",
+    gap: 20,
+  },
+  intervalLabel: {
+    alignItems: "center",
+  },
+  intervalLabelText: {
+    color: "#000",
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: 6,
+  },
+  noteLabel: {
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  noteLabelText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  pianoContainer: {
+    height: 140,
+    overflow: "hidden",
+    backgroundColor: "#f0f0f0",
+    borderRadius: 8,
+    marginVertical: 10,
+    position: "relative",
+  },
+  fixedHighlights: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 2,
+  },
+  pianoKeys: {
+    flexDirection: "row",
+    height: "100%",
+  },
+  pianoKey: {
+    position: "relative",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    paddingBottom: 8,
+  },
+  whiteKey: {
+    width: 35,
+    height: 120,
+    backgroundColor: "#fff",
+    borderRightWidth: 1,
+    borderRightColor: "#ccc",
+  },
+  blackKey: {
+    width: 24,
+    height: 70,
+    backgroundColor: "#000",
+    marginLeft: -12,
+    marginRight: -12,
+    zIndex: 1,
+  },
+  highlightedKey: {
+    position: "relative",
+  },
+  highlightBar: {
+    position: "absolute",
+    bottom: 0,
+    width: 6,
+    height: 90,
+    marginLeft: -3,
+    borderRadius: 3,
+    opacity: 0.8,
+  },
+
+  bottomSlider: {
+    marginTop: 8,
+  },
+  sliderTrack: {
+    height: 20,
+    backgroundColor: "#ccc",
+    borderRadius: 10,
+    position: "relative",
+  },
+  sliderIndicator: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#000",
+    position: "absolute",
+    top: 0,
+  },
+  rootIndicator: {
+    backgroundColor: "#000",
+  },
+  intervalIndicator: {
+    backgroundColor: "transparent",
+  },
+  minorThirdIndicator: {
+    backgroundColor: "#2196F3",
+  },
+  sliderIndicatorText: {
+    fontSize: 10,
+    fontWeight: "600",
+  },
+  chordTypeSection: {
+    alignItems: "center",
+  },
+  sectionTitle: {
+    color: Colors.primary,
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  chordTypeContainer: {
+    width: "100%",
+    gap: 12,
+  },
+  chordTypeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  chordTypeLabel: {
+    color: Colors.primary,
+    fontSize: 16,
+    fontWeight: "600",
+    minWidth: 60,
+  },
+  chordTypeButton: {
+    alignItems: "center",
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    borderRadius: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+    flex: 1,
+    minHeight: 60,
+  },
+  selectedChordTypeButton: {
+    backgroundColor: "rgba(255, 255, 255, 0.2)",
+    borderColor: Colors.primary,
+  },
+  chordTypeName: {
+    color: Colors.primary,
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: 8,
+  },
+  selectedChordTypeName: {
+    color: Colors.primary,
+    fontWeight: "700",
+  },
+  intervalButtons: {
+    flexDirection: "row",
+    gap: 4,
+  },
+  intervalButton: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#000",
+  },
+  activeIntervalButton: {
+    backgroundColor: "#333",
+  },
+  inactiveIntervalButton: {
+    backgroundColor: "#ccc",
+  },
+  activeIntervalButtonText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  inactiveIntervalButtonText: {
+    color: "#000",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  intervalButtonText: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  minorThirdButton: {
+    backgroundColor: "#2196F3",
+  },
+  flatSymbol: {
+    position: "absolute",
+    right: -8,
+    top: -2,
+    fontSize: 8,
+    color: "#000",
+    fontWeight: "600",
+  },
+  dropdownButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#ccc",
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    gap: 8,
+  },
+  dropdownButtonText: {
+    color: "#000",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  dropdownArrow: {
+    color: "#000",
+    fontSize: 12,
+  },
+}) 

--- a/src/navigation/screens/ChordProgressions.tsx
+++ b/src/navigation/screens/ChordProgressions.tsx
@@ -1,0 +1,412 @@
+import React, { useState, useMemo } from "react"
+import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { Ionicons } from "@expo/vector-icons"
+import Colors from "@/Colors"
+
+// Common chord progressions
+const COMMON_PROGRESSIONS: Record<string, {
+  name: string
+  chords: string[]
+  description: string
+  examples: string[]
+}> = {
+  pop: {
+    name: "Pop (I-V-vi-IV)",
+    chords: ["I", "V", "vi", "IV"],
+    description: "The most common pop progression",
+    examples: ["C-G-Am-F", "G-D-Em-C", "F-C-Dm-Bb"]
+  },
+  jazz: {
+    name: "Jazz (ii-V-I)",
+    chords: ["ii", "V", "I"],
+    description: "Classic jazz progression",
+    examples: ["Dm7-G7-Cmaj7", "Em7-A7-Dmaj7", "Am7-D7-Gmaj7"]
+  },
+  blues: {
+    name: "Blues (I-IV-V)",
+    chords: ["I", "IV", "V"],
+    description: "12-bar blues foundation",
+    examples: ["C-F-G", "G-C-D", "A-D-E"]
+  },
+  rock: {
+    name: "Rock (I-IV-V)",
+    chords: ["I", "IV", "V"],
+    description: "Classic rock progression",
+    examples: ["E-A-B", "A-D-E", "G-C-D"]
+  },
+  folk: {
+    name: "Folk (I-V-vi-IV)",
+    chords: ["I", "V", "vi", "IV"],
+    description: "Common folk progression",
+    examples: ["C-G-Am-F", "G-D-Em-C", "D-A-Bm-G"]
+  },
+  country: {
+    name: "Country (I-IV-V)",
+    chords: ["I", "IV", "V"],
+    description: "Traditional country",
+    examples: ["G-C-D", "C-F-G", "D-G-A"]
+  },
+  dooWop: {
+    name: "Doo-Wop (I-vi-IV-V)",
+    chords: ["I", "vi", "IV", "V"],
+    description: "Classic doo-wop progression",
+    examples: ["C-Am-F-G", "G-Em-C-D", "F-Dm-Bb-C"]
+  },
+  minor: {
+    name: "Minor (i-iv-V)",
+    chords: ["i", "iv", "V"],
+    description: "Minor key progression",
+    examples: ["Am-Dm-E", "Em-Am-B", "Dm-Gm-A"]
+  },
+}
+
+// Scale degrees to chord types
+const SCALE_DEGREES: Record<string, string> = {
+  "I": "major",
+  "ii": "minor",
+  "iii": "minor",
+  "IV": "major",
+  "V": "major",
+  "vi": "minor",
+  "vii°": "diminished",
+  "i": "minor",
+  "iv": "minor",
+}
+
+export const ChordProgressions: React.FC = () => {
+  const navigation = useNavigation()
+  const [selectedProgression, setSelectedProgression] = useState<keyof typeof COMMON_PROGRESSIONS>("pop")
+  const [selectedKey, setSelectedKey] = useState("C")
+
+  const selectedProgressionData = COMMON_PROGRESSIONS[selectedProgression]
+
+  // Calculate actual chords based on key and progression
+  const progressionChords = useMemo(() => {
+    const keyIndex = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"].indexOf(selectedKey)
+    if (keyIndex === -1) return []
+
+    const majorScale = [0, 2, 4, 5, 7, 9, 11] // C major scale intervals
+    const scaleNotes = majorScale.map(interval => (keyIndex + interval) % 12)
+
+    return selectedProgressionData.chords.map(degree => {
+      let degreeIndex: number
+      switch (degree) {
+        case "I": degreeIndex = 0; break
+        case "ii": degreeIndex = 1; break
+        case "iii": degreeIndex = 2; break
+        case "IV": degreeIndex = 3; break
+        case "V": degreeIndex = 4; break
+        case "vi": degreeIndex = 5; break
+        case "vii°": degreeIndex = 6; break
+        case "i": degreeIndex = 0; break
+        case "iv": degreeIndex = 3; break
+        default: degreeIndex = 0; break
+      }
+
+      const rootNote = scaleNotes[degreeIndex]
+      const chordType = SCALE_DEGREES[degree] || "major"
+      const noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+      
+      return {
+        degree,
+        rootNote: noteNames[rootNote],
+        chordType,
+        fullName: `${noteNames[rootNote]} ${chordType}`
+      }
+    })
+  }, [selectedKey, selectedProgressionData])
+
+  const handleProgressionSelect = (progression: keyof typeof COMMON_PROGRESSIONS) => {
+    setSelectedProgression(progression)
+  }
+
+  const handleKeySelect = (key: string) => {
+    setSelectedKey(key)
+  }
+
+  const handleBackPress = () => {
+    navigation.goBack()
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Back Button */}
+      <Pressable
+        onPress={handleBackPress}
+        style={styles.backButton}
+      >
+        <Ionicons name="arrow-back" size={24} color={Colors.primary} />
+      </Pressable>
+
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Chord Progressions</Text>
+      </View>
+
+      <ScrollView style={styles.scrollContainer} showsVerticalScrollIndicator={false}>
+        {/* Key Selection */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Select Key</Text>
+          <View style={styles.keyGrid}>
+            {["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"].map((key) => (
+              <Pressable
+                key={key}
+                onPress={() => handleKeySelect(key)}
+                style={[
+                  styles.keyButton,
+                  selectedKey === key && { backgroundColor: Colors.primary }
+                ]}
+              >
+                <Text style={[
+                  styles.keyButtonText,
+                  selectedKey === key && { color: "#000" }
+                ]}>
+                  {key}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+
+        {/* Progression Selection */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Select Progression</Text>
+          <View style={styles.progressionGrid}>
+            {Object.entries(COMMON_PROGRESSIONS).map(([key, progression]) => (
+              <Pressable
+                key={key}
+                onPress={() => handleProgressionSelect(key as keyof typeof COMMON_PROGRESSIONS)}
+                style={[
+                  styles.progressionButton,
+                  selectedProgression === key && { backgroundColor: Colors.primary }
+                ]}
+              >
+                <Text style={[
+                  styles.progressionButtonTitle,
+                  selectedProgression === key && { color: "#000" }
+                ]}>
+                  {progression.name}
+                </Text>
+                <Text style={[
+                  styles.progressionButtonDescription,
+                  selectedProgression === key && { color: "#000" }
+                ]}>
+                  {progression.description}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+
+        {/* Current Progression Display */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Current Progression</Text>
+          <View style={styles.progressionDisplay}>
+            <Text style={styles.progressionName}>{selectedProgressionData.name}</Text>
+            <Text style={styles.progressionDescription}>{selectedProgressionData.description}</Text>
+            
+            <View style={styles.chordSequence}>
+              {progressionChords.map((chord, index) => (
+                <View key={index} style={styles.chordItem}>
+                  <Text style={styles.chordDegree}>{chord.degree}</Text>
+                  <Text style={styles.chordName}>{chord.fullName}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        </View>
+
+        {/* Examples */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Examples in Different Keys</Text>
+          <View style={styles.examplesContainer}>
+            {selectedProgressionData.examples.map((example, index) => (
+              <View key={index} style={styles.exampleItem}>
+                <Text style={styles.exampleText}>{example}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        {/* Practice Tips */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Practice Tips</Text>
+          <View style={styles.tipsContainer}>
+            <Text style={styles.tipText}>
+              • Start by playing the progression slowly in the selected key
+            </Text>
+            <Text style={styles.tipText}>
+              • Practice transitioning between chords smoothly
+            </Text>
+            <Text style={styles.tipText}>
+              • Try different strumming patterns and rhythms
+            </Text>
+            <Text style={styles.tipText}>
+              • Experiment with adding extensions (7ths, 9ths, etc.)
+            </Text>
+            <Text style={styles.tipText}>
+              • Practice in different keys to improve your understanding
+            </Text>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.bgInactive,
+    paddingTop: 60,
+  },
+  backButton: {
+    position: "absolute",
+    top: 60,
+    left: 20,
+    zIndex: 1000,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: Colors.bgActive,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: Colors.secondary,
+  },
+  header: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255, 255, 255, 0.1)",
+  },
+  headerTitle: {
+    color: Colors.primary,
+    fontSize: 24,
+    fontWeight: "700",
+  },
+  scrollContainer: {
+    flex: 1,
+  },
+  section: {
+    marginBottom: 30,
+    paddingHorizontal: 20,
+  },
+  sectionTitle: {
+    color: Colors.primary,
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 15,
+  },
+  keyGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+  },
+  keyButton: {
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    minWidth: 40,
+    alignItems: "center",
+  },
+  keyButtonText: {
+    color: Colors.primary,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  progressionGrid: {
+    gap: 12,
+  },
+  progressionButton: {
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+  },
+  progressionButtonTitle: {
+    color: Colors.primary,
+    fontSize: 16,
+    fontWeight: "600",
+    marginBottom: 4,
+  },
+  progressionButtonDescription: {
+    color: Colors.secondary,
+    fontSize: 14,
+  },
+  progressionDisplay: {
+    backgroundColor: Colors.bgActive,
+    borderRadius: 12,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+  },
+  progressionName: {
+    color: Colors.primary,
+    fontSize: 20,
+    fontWeight: "600",
+    marginBottom: 8,
+  },
+  progressionDescription: {
+    color: Colors.secondary,
+    fontSize: 16,
+    marginBottom: 20,
+  },
+  chordSequence: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+    flexWrap: "wrap",
+    gap: 10,
+  },
+  chordItem: {
+    alignItems: "center",
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    borderRadius: 8,
+    padding: 12,
+    minWidth: 80,
+  },
+  chordDegree: {
+    color: Colors.secondary,
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  chordName: {
+    color: Colors.primary,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  examplesContainer: {
+    gap: 10,
+  },
+  exampleItem: {
+    backgroundColor: Colors.bgActive,
+    borderRadius: 8,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+  },
+  exampleText: {
+    color: Colors.primary,
+    fontSize: 16,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  tipsContainer: {
+    backgroundColor: Colors.bgActive,
+    borderRadius: 12,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+  },
+  tipText: {
+    color: Colors.secondary,
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 8,
+  },
+}) 

--- a/src/navigation/screens/CircleOfFifths.tsx
+++ b/src/navigation/screens/CircleOfFifths.tsx
@@ -1,0 +1,219 @@
+import React from "react"
+import { View, Text, StyleSheet, Pressable } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { Ionicons } from "@expo/vector-icons"
+import Colors from "@/Colors"
+import { useTranslation } from "@/configHooks"
+
+// Circle of fifths data
+const CIRCLE_OF_FIFTHS = [
+  { key: "C", sharps: 0, flats: 0, position: 0 },
+  { key: "G", sharps: 1, flats: 0, position: 1 },
+  { key: "D", sharps: 2, flats: 0, position: 2 },
+  { key: "A", sharps: 3, flats: 0, position: 3 },
+  { key: "E", sharps: 4, flats: 0, position: 4 },
+  { key: "B", sharps: 5, flats: 0, position: 5 },
+  { key: "F#", sharps: 6, flats: 0, position: 6 },
+  { key: "C#", sharps: 7, flats: 0, position: 7 },
+  { key: "F", sharps: 0, flats: 1, position: 8 },
+  { key: "Bb", sharps: 0, flats: 2, position: 9 },
+  { key: "Eb", sharps: 0, flats: 3, position: 10 },
+  { key: "Ab", sharps: 0, flats: 4, position: 11 },
+  { key: "Db", sharps: 0, flats: 5, position: 12 },
+  { key: "Gb", sharps: 0, flats: 6, position: 13 },
+  { key: "Cb", sharps: 0, flats: 7, position: 14 },
+] as const
+
+export const CircleOfFifths: React.FC = () => {
+  const navigation = useNavigation()
+  const t = useTranslation()
+
+  const handleBackPress = () => {
+    navigation.goBack()
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Back Button */}
+      <Pressable
+        onPress={handleBackPress}
+        style={styles.backButton}
+      >
+        <Ionicons name="arrow-back" size={24} color={Colors.primary} />
+      </Pressable>
+
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>{t("circle_of_fifths")}</Text>
+      </View>
+
+      {/* Content */}
+      <View style={styles.content}>
+        <View style={styles.circleContainer}>
+          <View style={styles.circleCenter}>
+            <Text style={styles.circleCenterText}>KEY</Text>
+          </View>
+          
+          {CIRCLE_OF_FIFTHS.slice(0, 12).map((keyData, index) => {
+            const angle = (index * 30) - 90 // Start from top
+            const radius = 120
+            const x = Math.cos(angle * Math.PI / 180) * radius
+            const y = Math.sin(angle * Math.PI / 180) * radius
+            
+            return (
+              <View
+                key={keyData.key}
+                style={[
+                  styles.circleKey,
+                  {
+                    transform: [{ translateX: x }, { translateY: y }],
+                    backgroundColor: "rgba(255, 255, 255, 0.1)",
+                  },
+                ]}
+              >
+                <Text style={styles.circleKeyText}>
+                  {keyData.key}
+                </Text>
+                <Text style={styles.circleKeyInfo}>
+                  {keyData.sharps > 0 ? `${keyData.sharps}♯` : keyData.flats > 0 ? `${keyData.flats}♭` : 'Nat'}
+                </Text>
+              </View>
+            )
+          })}
+        </View>
+
+        <Text style={styles.description}>
+          The Circle of Fifths shows the relationship between keys. Moving clockwise adds sharps, counterclockwise adds flats.
+        </Text>
+
+        {/* Additional Information */}
+        <View style={styles.infoSection}>
+          <Text style={styles.infoTitle}>How to Use:</Text>
+          <Text style={styles.infoText}>
+            • Clockwise movement adds sharps (G, D, A, E, B, F#, C#)
+          </Text>
+          <Text style={styles.infoText}>
+            • Counterclockwise movement adds flats (F, Bb, Eb, Ab, Db, Gb, Cb)
+          </Text>
+          <Text style={styles.infoText}>
+            • Related keys are adjacent in the circle
+          </Text>
+          <Text style={styles.infoText}>
+            • Perfect for understanding key signatures and chord progressions
+          </Text>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.bgInactive,
+    paddingTop: 60,
+  },
+  backButton: {
+    position: "absolute",
+    top: 60,
+    left: 20,
+    zIndex: 1000,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: Colors.bgActive,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: Colors.secondary,
+  },
+  header: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255, 255, 255, 0.1)",
+  },
+  headerTitle: {
+    color: Colors.primary,
+    fontSize: 24,
+    fontWeight: "700",
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+    alignItems: "center",
+  },
+  circleContainer: {
+    width: 280,
+    height: 280,
+    position: "relative",
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 30,
+  },
+  circleCenter: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: "rgba(58, 58, 58, 0.8)",
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 2,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+  },
+  circleCenterText: {
+    color: Colors.primary,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  circleKey: {
+    position: "absolute",
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+  },
+  circleKeyText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: Colors.primary,
+  },
+  circleKeyInfo: {
+    fontSize: 10,
+    marginTop: 2,
+    color: Colors.secondary,
+  },
+  description: {
+    color: Colors.secondary,
+    fontSize: 16,
+    textAlign: "center",
+    lineHeight: 24,
+    marginBottom: 30,
+    paddingHorizontal: 20,
+  },
+  infoSection: {
+    backgroundColor: Colors.bgActive,
+    borderRadius: 12,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+    width: "100%",
+  },
+  infoTitle: {
+    color: Colors.primary,
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 15,
+  },
+  infoText: {
+    color: Colors.secondary,
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 8,
+  },
+}) 

--- a/src/navigation/screens/Home.tsx
+++ b/src/navigation/screens/Home.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { View, Text, Pressable, StyleSheet } from "react-native"
+import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { Ionicons } from "@expo/vector-icons"
 import Colors from "@/Colors"
@@ -7,22 +7,18 @@ import Colors from "@/Colors"
 export function Home() {
   const navigation = useNavigation()
   const [activeTab, setActiveTab] = useState("home")
-
-  const handleTonusVivoPress = () => {
-    navigation.navigate("Tuneo" as never)
-  }
+  const [activeSection, setActiveSection] = useState<string | null>(null)
 
   const handleTabPress = (tabName: string) => {
     setActiveTab(tabName)
     
     // Handle navigation for different tabs
     switch (tabName) {
-      case "tuner":
+      case "tonusVivo":
         navigation.navigate("Tuneo" as never)
         break
-      case "metronome":
-        // TODO: Navigate to metronome screen
-        // Metronome functionality coming soon
+      case "chords":
+        navigation.navigate("MusicTheory" as never)
         break
       case "lessons":
         navigation.navigate("Lessons" as never)
@@ -33,6 +29,10 @@ export function Home() {
     }
   }
 
+  const handleSectionPress = (section: string) => {
+    setActiveSection(activeSection === section ? null : section)
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -40,22 +40,142 @@ export function Home() {
         <Text style={styles.subtitle}>Your Music Companion</Text>
       </View>
       
-      <View style={styles.content}>
-        <Pressable style={styles.card} onPress={handleTonusVivoPress}>
-          <View style={styles.cardContent}>
-            <View style={styles.cardIcon}>
-              <Ionicons name="musical-note" size={40} color={Colors.primary} />
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        {/* Welcome Section */}
+        <View style={styles.welcomeSection}>
+          <Text style={styles.welcomeTitle}>Welcome to Music Theory</Text>
+          <Text style={styles.welcomeDescription}>
+            Learn the fundamentals of music theory and discover essential concepts to enhance your musical journey.
+          </Text>
+        </View>
+
+        {/* Music Theory Basics */}
+        <View style={styles.section}>
+          <Pressable
+            style={styles.sectionHeader}
+            onPress={() => handleSectionPress("basics")}
+          >
+            <View style={styles.sectionHeaderContent}>
+              <View style={styles.sectionIcon}>
+                <Ionicons name="book" size={24} color={Colors.primary} />
+              </View>
+              <View style={styles.sectionText}>
+                <Text style={styles.sectionTitle}>Theory Basics</Text>
+                <Text style={styles.sectionDescription}>
+                  Fundamental music theory concepts and terminology
+                </Text>
+              </View>
             </View>
-            <View style={styles.cardText}>
-              <Text style={styles.cardTitle}>Tonus Vivo</Text>
-              <Text style={styles.cardDescription}>Precision tuning for your instruments</Text>
+            <Ionicons 
+              name={activeSection === "basics" ? "chevron-up" : "chevron-down"} 
+              size={20} 
+              color={Colors.secondary} 
+            />
+          </Pressable>
+          
+          {activeSection === "basics" && (
+            <View style={styles.sectionContent}>
+              <View style={styles.basicsContainer}>
+                <View style={styles.basicItem}>
+                  <Text style={styles.basicTitle}>Intervals</Text>
+                  <Text style={styles.basicDescription}>
+                    The distance between two notes. Understanding intervals is crucial for building chords and melodies.
+                  </Text>
+                </View>
+                
+                <View style={styles.basicItem}>
+                  <Text style={styles.basicTitle}>Scales</Text>
+                  <Text style={styles.basicDescription}>
+                    A series of notes in ascending or descending order. The major and minor scales are the foundation of Western music.
+                  </Text>
+                </View>
+                
+                <View style={styles.basicItem}>
+                  <Text style={styles.basicTitle}>Keys</Text>
+                  <Text style={styles.basicDescription}>
+                    A group of pitches that form the basis of a musical composition. Each key has its own set of sharps or flats.
+                  </Text>
+                </View>
+                
+                <View style={styles.basicItem}>
+                  <Text style={styles.basicTitle}>Time Signatures</Text>
+                  <Text style={styles.basicDescription}>
+                    Indicates how many beats are in each measure and which note value constitutes one beat.
+                  </Text>
+                </View>
+              </View>
             </View>
-            <View style={styles.cardArrow}>
-              <Ionicons name="chevron-forward" size={24} color={Colors.secondary} />
+          )}
+        </View>
+
+        {/* Practice Tips */}
+        <View style={styles.section}>
+          <Pressable
+            style={styles.sectionHeader}
+            onPress={() => handleSectionPress("tips")}
+          >
+            <View style={styles.sectionHeaderContent}>
+              <View style={styles.sectionIcon}>
+                <Ionicons name="bulb" size={24} color={Colors.primary} />
+              </View>
+              <View style={styles.sectionText}>
+                <Text style={styles.sectionTitle}>Practice Tips</Text>
+                <Text style={styles.sectionDescription}>
+                  Effective strategies for learning and applying music theory
+                </Text>
+              </View>
             </View>
-          </View>
-        </Pressable>
-      </View>
+            <Ionicons 
+              name={activeSection === "tips" ? "chevron-up" : "chevron-down"} 
+              size={20} 
+              color={Colors.secondary} 
+            />
+          </Pressable>
+          
+          {activeSection === "tips" && (
+            <View style={styles.sectionContent}>
+              <View style={styles.tipsContainer}>
+                <View style={styles.tipItem}>
+                  <Ionicons name="checkmark-circle" size={20} color={Colors.primary} />
+                  <Text style={styles.tipText}>
+                    Start with basic intervals and gradually build to more complex concepts
+                  </Text>
+                </View>
+                
+                <View style={styles.tipItem}>
+                  <Ionicons name="checkmark-circle" size={20} color={Colors.primary} />
+                  <Text style={styles.tipText}>
+                    Practice identifying chords and progressions in your favorite songs
+                  </Text>
+                </View>
+                
+                <View style={styles.tipItem}>
+                  <Ionicons name="checkmark-circle" size={20} color={Colors.primary} />
+                  <Text style={styles.tipText}>
+                    Use the Circle of Fifths to understand key relationships
+                  </Text>
+                </View>
+                
+                <View style={styles.tipItem}>
+                  <Ionicons name="checkmark-circle" size={20} color={Colors.primary} />
+                  <Text style={styles.tipText}>
+                    Experiment with different chord voicings and inversions
+                  </Text>
+                </View>
+                
+                <View style={styles.tipItem}>
+                  <Ionicons name="checkmark-circle" size={20} color={Colors.primary} />
+                  <Text style={styles.tipText}>
+                    Apply theory concepts to your own compositions and improvisations
+                  </Text>
+                </View>
+              </View>
+            </View>
+          )}
+        </View>
+
+
+      </ScrollView>
       
       {/* Floating Navigation Bar */}
       <View style={styles.floatingNav}>
@@ -74,30 +194,30 @@ export function Home() {
         </Pressable>
         
         <Pressable
-          style={[styles.navItem, activeTab === "tuner" && styles.navItemActive]}
-          onPress={() => handleTabPress("tuner")}
+          style={[styles.navItem, activeTab === "tonusVivo" && styles.navItemActive]}
+          onPress={() => handleTabPress("tonusVivo")}
         >
           <Ionicons 
             name="musical-note" 
             size={24} 
-            color={activeTab === "tuner" ? Colors.primary : Colors.secondary} 
+            color={activeTab === "tonusVivo" ? Colors.primary : Colors.secondary} 
           />
-          <Text style={[styles.navLabel, activeTab === "tuner" && styles.navLabelActive]}>
-            Tuner
+          <Text style={[styles.navLabel, activeTab === "tonusVivo" && styles.navLabelActive]}>
+            Tonus Vivo
           </Text>
         </Pressable>
         
         <Pressable
-          style={[styles.navItem, activeTab === "metronome" && styles.navItemActive]}
-          onPress={() => handleTabPress("metronome")}
+          style={[styles.navItem, activeTab === "chords" && styles.navItemActive]}
+          onPress={() => handleTabPress("chords")}
         >
           <Ionicons 
-            name="timer" 
+            name="compass" 
             size={24} 
-            color={activeTab === "metronome" ? Colors.primary : Colors.secondary} 
+            color={activeTab === "chords" ? Colors.primary : Colors.secondary} 
           />
-          <Text style={[styles.navLabel, activeTab === "metronome" && styles.navLabelActive]}>
-            Metronome
+          <Text style={[styles.navLabel, activeTab === "chords" && styles.navLabelActive]}>
+            Chords
           </Text>
         </Pressable>
         
@@ -127,7 +247,7 @@ const styles = StyleSheet.create({
   header: {
     paddingTop: 60,
     paddingHorizontal: 20,
-    paddingBottom: 40,
+    paddingBottom: 20,
     alignItems: "center",
   },
   title: {
@@ -145,51 +265,106 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingBottom: 120, // Add padding to avoid floating nav
   },
-  card: {
-    backgroundColor: Colors.bgActive,
-    borderRadius: 16,
-    padding: 20,
-    marginBottom: 16,
-    borderWidth: 1,
-    borderColor: Colors.secondary,
-    shadowColor: "#000",
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 3,
+  welcomeSection: {
+    paddingVertical: 20,
+    alignItems: "center",
   },
-  cardContent: {
+  welcomeTitle: {
+    fontSize: 24,
+    fontWeight: "bold",
+    color: Colors.primary,
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  welcomeDescription: {
+    fontSize: 14,
+    color: Colors.secondary,
+    textAlign: "center",
+    lineHeight: 20,
+    maxWidth: 300,
+  },
+  section: {
+    marginBottom: 16,
+  },
+  sectionHeader: {
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: Colors.bgActive,
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
   },
-  cardIcon: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    backgroundColor: Colors.bgInactive,
-    justifyContent: "center",
+  sectionHeaderContent: {
+    flexDirection: "row",
     alignItems: "center",
-    marginRight: 16,
-  },
-  cardText: {
     flex: 1,
   },
-  cardTitle: {
-    fontSize: 20,
+  sectionIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "rgba(58, 58, 58, 0.8)",
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 12,
+  },
+  sectionText: {
+    flex: 1,
+  },
+  sectionTitle: {
+    fontSize: 16,
     fontWeight: "600",
     color: Colors.primary,
     marginBottom: 4,
   },
-  cardDescription: {
-    fontSize: 14,
+  sectionDescription: {
+    fontSize: 12,
     color: Colors.secondary,
   },
-  cardArrow: {
-    marginLeft: 8,
+  sectionContent: {
+    backgroundColor: Colors.bgActive,
+    borderRadius: 12,
+    marginTop: 8,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
   },
+  basicsContainer: {
+    gap: 16,
+  },
+  basicItem: {
+    paddingBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255, 255, 255, 0.1)",
+  },
+  basicTitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: Colors.primary,
+    marginBottom: 6,
+  },
+  basicDescription: {
+    fontSize: 12,
+    color: Colors.secondary,
+    lineHeight: 18,
+  },
+  tipsContainer: {
+    gap: 12,
+  },
+  tipItem: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 10,
+  },
+  tipText: {
+    fontSize: 12,
+    color: Colors.secondary,
+    lineHeight: 18,
+    flex: 1,
+  },
+
   floatingNav: {
     position: "absolute",
     bottom: 30,

--- a/src/navigation/screens/MusicTheory.tsx
+++ b/src/navigation/screens/MusicTheory.tsx
@@ -1,0 +1,186 @@
+import React from "react"
+import { View, Text, StyleSheet, ScrollView, Pressable } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { Ionicons } from "@expo/vector-icons"
+import Colors from "@/Colors"
+
+export const MusicTheory: React.FC = () => {
+  const navigation = useNavigation()
+
+  const handleOpenChordCompass = () => {
+    navigation.navigate("ChordCompass" as never)
+  }
+
+  const handleOpenCircleOfFifths = () => {
+    navigation.navigate("CircleOfFifths" as never)
+  }
+
+  const handleOpenChordProgressions = () => {
+    navigation.navigate("ChordProgressions" as never)
+  }
+
+  const handleBackPress = () => {
+    navigation.goBack()
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Back Button */}
+      <Pressable
+        onPress={handleBackPress}
+        style={styles.backButton}
+      >
+        <Ionicons name="arrow-back" size={24} color={Colors.primary} />
+      </Pressable>
+
+      <ScrollView style={styles.scrollContainer} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Chords & Progressions</Text>
+        </View>
+
+        <View style={styles.content}>
+          {/* Chord Compass Card */}
+          <Pressable
+            style={styles.card}
+            onPress={handleOpenChordCompass}
+          >
+            <View style={styles.cardContent}>
+              <View style={styles.cardIcon}>
+                <Ionicons name="compass" size={24} color={Colors.primary} />
+              </View>
+              <View style={styles.cardText}>
+                <Text style={styles.cardTitle}>Chord Compass</Text>
+                <Text style={styles.cardDescription}>
+                  Interactive chord builder with piano visualization
+                </Text>
+              </View>
+              <View style={styles.cardArrow}>
+                <Ionicons name="chevron-forward" size={24} color={Colors.secondary} />
+              </View>
+            </View>
+          </Pressable>
+
+          {/* Circle of Fifths Card */}
+          <Pressable
+            style={styles.card}
+            onPress={handleOpenCircleOfFifths}
+          >
+            <View style={styles.cardContent}>
+              <View style={styles.cardIcon}>
+                <Ionicons name="refresh-circle" size={24} color={Colors.primary} />
+              </View>
+              <View style={styles.cardText}>
+                <Text style={styles.cardTitle}>Circle of Fifths</Text>
+                <Text style={styles.cardDescription}>
+                  Visual key relationships and chord progressions
+                </Text>
+              </View>
+              <View style={styles.cardArrow}>
+                <Ionicons name="chevron-forward" size={24} color={Colors.secondary} />
+              </View>
+            </View>
+          </Pressable>
+
+          {/* Chord Progressions Card */}
+          <Pressable
+            style={styles.card}
+            onPress={handleOpenChordProgressions}
+          >
+            <View style={styles.cardContent}>
+              <View style={styles.cardIcon}>
+                <Ionicons name="musical-notes" size={24} color={Colors.primary} />
+              </View>
+              <View style={styles.cardText}>
+                <Text style={styles.cardTitle}>Chord Progressions</Text>
+                <Text style={styles.cardDescription}>
+                  Explore and practice common chord progressions
+                </Text>
+              </View>
+              <View style={styles.cardArrow}>
+                <Ionicons name="chevron-forward" size={24} color={Colors.secondary} />
+              </View>
+            </View>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.bgInactive,
+  },
+  backButton: {
+    position: "absolute",
+    top: 50,
+    left: 20,
+    zIndex: 1000,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: Colors.bgActive,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: Colors.secondary,
+  },
+  scrollContainer: {
+    flex: 1,
+  },
+  header: {
+    paddingTop: 100,
+    paddingBottom: 20,
+    paddingHorizontal: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255, 255, 255, 0.1)",
+  },
+  title: {
+    color: Colors.primary,
+    fontSize: 24,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+  content: {
+    padding: 20,
+  },
+  card: {
+    marginBottom: 20,
+    backgroundColor: Colors.bgActive,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+    overflow: "hidden",
+  },
+  cardContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 16,
+  },
+  cardIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "rgba(58, 58, 58, 0.8)",
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 12,
+  },
+  cardText: {
+    flex: 1,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: Colors.primary,
+    marginBottom: 4,
+  },
+  cardDescription: {
+    fontSize: 14,
+    color: Colors.secondary,
+  },
+  cardArrow: {
+    marginLeft: 12,
+  },
+}) 

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -13,6 +13,13 @@ export interface Translation {
   error_mic_access: string
   configure_permissions: string
   select_tuning: string
+  chord_compass: string
+  key_selection: string
+  chord_types: string
+  current_chord: string
+  circle_of_fifths: string
+  formula: string
+  notes: string
 }
 
 export const en: Translation = {
@@ -30,6 +37,13 @@ export const en: Translation = {
   error_mic_access: "Tuneo requires microphone permissions to hear your guitar.",
   configure_permissions: "Configure permissions",
   select_tuning: "Select Tuning",
+  chord_compass: "Chord Compass",
+  key_selection: "Key Selection",
+  chord_types: "Chord Types",
+  current_chord: "Current Chord",
+  circle_of_fifths: "Circle of Fifths",
+  formula: "Formula",
+  notes: "Notes",
 }
 
 export const es: Translation = {
@@ -47,4 +61,11 @@ export const es: Translation = {
   error_mic_access: "Tuneo necesita permiso de micrófono para escuchar la guitarra.",
   configure_permissions: "Configurar permisos",
   select_tuning: "Seleccionar Afinación",
+  chord_compass: "Compás de Acordes",
+  key_selection: "Selección de Tonalidad",
+  chord_types: "Tipos de Acordes",
+  current_chord: "Acorde Actual",
+  circle_of_fifths: "Círculo de Quintas",
+  formula: "Fórmula",
+  notes: "Notas",
 }


### PR DESCRIPTION


- Fixed piano sliding to account for actual key sizes (white-to-white vs black-to-white transitions)
- Aligned bottom slider indicators with piano indicators above
- Made piano indicators taller by 6px for better visibility
- Improved spacing calculations for B->C and E->F transitions
- Moved indicators to left side of piano container
- Fixed boundary behavior (no looping, stops at C and B)